### PR TITLE
Add meaning to Abbreviation

### DIFF
--- a/docs/OODEXPLAINED.txt
+++ b/docs/OODEXPLAINED.txt
@@ -1,4 +1,4 @@
-In our OOD 
+In our OOD (Object Oriented Design)
 we have created classes that handle the game logc and UI design seperately.
 
 To Draw the game board, we have


### PR DESCRIPTION
Abbreviation makes documentation unclear as it has different meanings depending on the context.
The meaning of OOD needs to be added next to it.
"OOD" -> "OOD (Object Oriented Design)