### PR TITLE
Remove ambiguity in first 3 lines of 2nd paragraph

### DIFF
--- a/docs/OODEXPLAINED.txt
+++ b/docs/OODEXPLAINED.txt
@@ -5,10 +5,9 @@ To Draw the game board,
 -a Board class is designed to store a grid of Cell objects.
 -For every user input, the status of affected cell is changed and the board object is updated accordingly.
 
-
-To handle the active tank collection and fortress health
--we have designed a class called Tank that is used to instantiate each tank on the board
--Each tank holds its own attributes such as health, damage and shape (essentially the coordinates)
+To handle the active tank collection and fortress health,
+-a Tank class is designed to instantiate each Tank object on the Board object.
+-each Tankobject  holds its own attributes such as health, damage and shape (essentially the coordinates).
 -We then create a class called TankCollection that holds the entire collection of tanks in it
 -TankCollection has its own attributes (like cumalativeDmgOutput) which are calculated based the cumulative attributes of all tanks within it
 -We create a class called Fortress that hols the health of the user's Fortress


### PR DESCRIPTION
Changed the sentence "we have designed a class called Tank that is used to instantiate each tank on the board." to "a Tank class is designed to instantiate each Tank object on the Board object." to remove pronouns and to make it clear what "tank on the board" means.
Added a comma at the end of "To handle the active tank collection and fortress health". 
"Each tank" is changed to "each Tank object" for clarity. Added a full stop at the end of this sentence.