### PR TITLE
Fixed the 3rd paragraph

### DIFF
--- a/docs/OODEXPLAINED.txt
+++ b/docs/OODEXPLAINED.txt
@@ -13,12 +13,11 @@ To handle the active tank collection and fortress health,
 -We create a class called Fortress that hols the health of the user's Fortress
 -Based on the status of tanks in the TankCollection object, we reduce the health of our fortress accordingly until the user wins/loses
 
-To instantiate and initialize the board with tanks, we
-Create a Game class which
--adds tanks to the Board object
--updates the board object
--checks if the user is victorious or not (ie the user loses)
--displays the first introductory message on the screen
+To instantiate and initialize the Board object with Tank objects, a Game class is designed to
+-add Tank object to the Board object.
+-update the Board object.
+-check if user is victorious.
+-display first introductory message on screen.
 
 To handle Ui
 We design a display class called Display that


### PR DESCRIPTION
Changed  "boards" and "tanks" to "Board object" and "Tank object"  to remove ambiguity and for consistency.
Added full stops at the end of each description.
Avoid using "ie" in a technical documentation.
Removed unnecessary "the" from each description.