### PR TITLE
Fixed fourth paragraph

### DIFF
--- a/docs/OODEXPLAINED.txt
+++ b/docs/OODEXPLAINED.txt
@@ -20,8 +20,7 @@ Create a Game class which
 -checks if the user is victorious or not (ie the user loses)
 -displays the first introductory message on the screen
 
-To handle Ui
-We design a display class called Display that
--displays the active board grid with the status of each and every cell
--display the damage output of every tank
--displays health of fortress
+To handle Ui,a Display class is designed to
+-display the grid of Board Object and the status of Cell objects.
+-display damage output of Tank objects.
+-display health of Fortress objects.


### PR DESCRIPTION
Changed "display class called Display" to "a Display class" to remove redundancy.
Changed "active board grid" to "grid of Board object" for clarity.
Added the word  "objects" after class names to remove ambiguity.
Removed "each and every " to remove redundancy.
Removed pronoun "we".
Added full stop at the end of each display description.