### PR TITLE
Fixed "Tankobject" grammatical error and removed extra space

### DIFF
--- a/docs/OODEXPLAINED.txt
+++ b/docs/OODEXPLAINED.txt
@@ -7,7 +7,7 @@ To Draw the game board,
 
 To handle the active tank collection and fortress health,
 -a Tank class is designed to instantiate each Tank object on the Board object.
--each Tankobject  holds its own attributes such as health, damage and shape (essentially the coordinates).
+-each Tank object holds its own attributes such as health, damage and shape (essentially the coordinates).
 -We then create a class called TankCollection that holds the entire collection of tanks in it
 -TankCollection has its own attributes (like cumalativeDmgOutput) which are calculated based the cumulative attributes of all tanks within it
 -We create a class called Fortress that hols the health of the user's Fortress


### PR DESCRIPTION
Changed "Tankobject" to "Tank object" and removed extra space between "object" and "holds".